### PR TITLE
support optional Newline after CR

### DIFF
--- a/src/pipehat/const.clj
+++ b/src/pipehat/const.clj
@@ -5,5 +5,6 @@
 (def ^{:const true :doc "The HL7 Minimal Lower Layer Protocol (MLLP) end-of-block character."} EB 0x1C)
 (def ^{:const true :doc "The ASCII form feed character."} FF 0x0C)
 (def ^{:const true :doc "The ASCII carriage return character."} CR 0x0D)
+(def ^{:const true :doc "The ASCII carriage return character."} NL 0x0A)
 (def ^{:const true :doc "The ASCII acknowledgement character."} ACK 0x06)
 (def ^{:const true :doc "The ASCII negative acknowledgement character."} NAK 0x15)


### PR DESCRIPTION
I can rework to add configuration or keep it this in a fork, but we have found if pretty common for people to diverge from the standard on new lines for some  reason. 